### PR TITLE
Remove opentelemetry-exporter-logging because it doesnt work on RDE i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 OTEL_SERVICE_NAME=aem-author
 ```
 
-For local debugging you can use the logging exporter to print to the console.
+For local debugging, add the `opentelemetry-exporter-logging` bundle to your `all` package in start level `15` with a specific profile for
+local development, so that you can use the logging exporter to print to the console.
 
 ```text
 OTEL_TRACES_EXPORTER=logging

--- a/opentelemetry-okhttp-exporter/pom.xml
+++ b/opentelemetry-okhttp-exporter/pom.xml
@@ -59,13 +59,6 @@
                         </embedded>
                         <embedded>
                             <groupId>be.orbinson.osgi</groupId>
-                            <artifactId>opentelemetry-exporter-logging</artifactId>
-                            <target>
-                                /apps/aemaacs-opentelemetry-instrumentation-opentelemetry-okhttp-exporter-packages/application/install/15
-                            </target>
-                        </embedded>
-                        <embedded>
-                            <groupId>be.orbinson.osgi</groupId>
                             <artifactId>opentelemetry-exporter-otlp</artifactId>
                             <target>
                                 /apps/aemaacs-opentelemetry-instrumentation-opentelemetry-okhttp-exporter-packages/application/install/15
@@ -364,11 +357,6 @@
         <dependency>
             <groupId>be.orbinson.osgi</groupId>
             <artifactId>opentelemetry-exporter-common</artifactId>
-            <version>${opentelemetry.version}.0001</version>
-        </dependency>
-        <dependency>
-            <groupId>be.orbinson.osgi</groupId>
-            <artifactId>opentelemetry-exporter-logging</artifactId>
             <version>${opentelemetry.version}.0001</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
…f you have multiple ServiceLoader Producers of the same interface